### PR TITLE
Misc fixes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -50,11 +50,11 @@ nbsphinx_allow_errors = True
 nbsphinx_prolog = """
 {% set docname = env.doc2path(env.docname, base=None) %}
 
-You can run this notebook in a `live session <https://mybinder.org/v2/gh/pydata/xarray-tutorial/master?urlpath=lab/tree/{{
-docname }}>`_ |Binder| or view it `on Github <https://github.com/pydata/xarray-tutorial/blob/master/{{ docname }}>`_.
+You can run this notebook in a `live session <https://mybinder.org/v2/gh/xarray-contrib/xarray-tutorial/master?urlpath=lab/tree/{{
+docname }}>`_ |Binder| or view it `on Github <https://github.com/xarray-contrib/xarray-tutorial/blob/master/{{ docname }}>`_.
 
 .. |Binder| image:: https://mybinder.org/badge.svg
-   :target: https://mybinder.org/v2/gh/pydata/xarray-tutorial/master?urlpath=lab/tree/{{ docname }}
+   :target: https://mybinder.org/v2/gh/xarray-contrib/xarray-tutorial/master?urlpath=lab/tree/{{ docname }}
 """
 
 

--- a/scipy-tutorial/00_overview.ipynb
+++ b/scipy-tutorial/00_overview.ipynb
@@ -126,7 +126,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
    "outputs": [],
    "source": [
     "print(\"Hello, world!\")"

--- a/scipy-tutorial/06_xarray_and_dask.ipynb
+++ b/scipy-tutorial/06_xarray_and_dask.ipynb
@@ -358,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# apply_ufunc\n",
+    "## apply_ufunc\n",
     "\n",
     "`apply_ufunc` is a more advanced wrapper that is designed to apply functions\n",
     "that expect and return NumPy (or other arrays). For example, this would include\n",


### PR DESCRIPTION
While looking at the notebooks I noticed a few issues:
- the binder links are dead
- the solution cell is not hidden by default
- the `apply_ufunc` chapter became a new session, even though it shares a notebook. I guess that's not intentional?

To actually hide cells we need to make sure the [`jupyter.source_hidden` attribute](https://discourse.jupyter.org/t/hiding-code-cell-on-launch/1763) are set.