### PR TITLE
Fix xrft link

### DIFF
--- a/oceanhackweek-2020/xarray-oceanhackweek20.ipynb
+++ b/oceanhackweek-2020/xarray-oceanhackweek20.ipynb
@@ -1200,7 +1200,7 @@
     "\n",
     "- [xgcm](https://xgcm.readthedocs.io/) : grid-aware operations with xarray\n",
     "  objects\n",
-    "- [xrft](https://xgcm.readthedocs.io/) : fourier transforms with xarray\n",
+    "- [xrft](https://xrft.readthedocs.io/) : fourier transforms with xarray\n",
     "- [xclim](https://xclim.readthedocs.io/) : calculating climate indices with\n",
     "  xarray objects\n",
     "- [intake-xarray](https://intake-xarray.readthedocs.io/) : forget about file\n",


### PR DESCRIPTION
Fix xrtf docs link on the [_Xarray in 45 minutes_](https://xarray-contrib.github.io/xarray-tutorial/oceanhackweek-2020/xarray-oceanhackweek20.html#Other-cool-packages) page.