### PR TITLE
fix the failing Tutorial Testing CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install graphviz
       - name: Set up Python 3.8
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
            channels: conda-forge
            mamba-version: "*"


### PR DESCRIPTION
as far as I can tell the CI failed because we were using the old location (and version) of `setup-miniconda`.

cc @andersy005 