### PR TITLE
Reorganize apply_ufunc/map_blocks material

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -36,7 +36,14 @@ parts:
 
   - caption: Advanced
     chapters:
-      - file: advanced/parallelize-custom-functions
+      - file: advanced/parallel-intro.md
+      - file: advanced/apply_ufunc/apply_ufunc.md
+        sections:
+          - file: advanced/apply_ufunc/simple_apply_ufunc
+          - file: advanced/apply_ufunc/vectorize_1d
+      - file: advanced/map_blocks/map_blocks.md
+        sections:
+          - file: advanced/map_blocks/simple_map_blocks
       - file: advanced/backends/backends.md
         sections:
           - file: advanced/backends/1.Backend_without_Lazy_Loading.ipynb

--- a/_toc.yml
+++ b/_toc.yml
@@ -28,15 +28,18 @@ parts:
           - file: fundamentals/04.2_faceting
           - file: fundamentals/04.3_geographic_plotting
 
-  - caption: Intermediate
+  - caption: Concepts
     chapters:
       - file: intermediate/01-high-level-computation-patterns
+      - file: advanced/parallel-intro.md
+
+  - caption: Intermediate
+    chapters:
       - file: intermediate/xarray_and_dask
       - file: intermediate/hvplot
 
   - caption: Advanced
     chapters:
-      - file: advanced/parallel-intro.md
       - file: advanced/apply_ufunc/apply_ufunc.md
         sections:
           - file: advanced/apply_ufunc/simple_apply_ufunc

--- a/_toc.yml
+++ b/_toc.yml
@@ -28,19 +28,16 @@ parts:
           - file: fundamentals/04.2_faceting
           - file: fundamentals/04.3_geographic_plotting
 
-  - caption: Concepts
-    chapters:
-      - file: intermediate/01-high-level-computation-patterns
-      - file: advanced/parallel-intro.md
-
   - caption: Intermediate
     chapters:
+      - file: intermediate/01-high-level-computation-patterns
       - file: intermediate/xarray_and_dask
       - file: intermediate/xarray_ecosystem
       - file: intermediate/hvplot
 
   - caption: Advanced
     chapters:
+      - file: advanced/parallel-intro.md
       - file: advanced/apply_ufunc/apply_ufunc.md
         sections:
           - file: advanced/apply_ufunc/simple_numpy_apply_ufunc

--- a/_toc.yml
+++ b/_toc.yml
@@ -42,7 +42,8 @@ parts:
     chapters:
       - file: advanced/apply_ufunc/apply_ufunc.md
         sections:
-          - file: advanced/apply_ufunc/simple_apply_ufunc
+          - file: advanced/apply_ufunc/simple_numpy_apply_ufunc
+          - file: advanced/apply_ufunc/simple_dask_apply_ufunc
           - file: advanced/apply_ufunc/vectorize_1d
       - file: advanced/map_blocks/map_blocks.md
         sections:

--- a/advanced/apply_ufunc/apply_ufunc.md
+++ b/advanced/apply_ufunc/apply_ufunc.md
@@ -1,0 +1,5 @@
+# apply_ufunc
+
+```{tableofcontents}
+
+```

--- a/advanced/apply_ufunc/simple_apply_ufunc.ipynb
+++ b/advanced/apply_ufunc/simple_apply_ufunc.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "<a id='applymap'></a>\n",
     "\n",
-    "# Parallelizing custom functions with apply_ufunc and map_blocks\n",
+    "# A gentle introduction\n",
     "\n",
     "## Setup"
    ]
@@ -96,111 +96,6 @@
     "    },\n",
     ")\n",
     "ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c15378b9-2a5b-4d0d-a96c-320b09a6a7bd",
-   "metadata": {},
-   "source": [
-    "## Introduction\n",
-    "\n",
-    "Almost all of xarray’s built-in operations work on Dask arrays.\n",
-    "\n",
-    "Sometimes analysis calls for functions that aren't in xarray's API (e.g. scipy).\n",
-    "There are three ways to apply these functions in parallel on each block of your\n",
-    "xarray object:\n",
-    "\n",
-    "1. Extract Dask arrays from xarray objects (`.data`) and use Dask directly e.g.\n",
-    "   (`apply_gufunc`, `map_blocks`, `map_overlap`, or `blockwise`)\n",
-    "\n",
-    "2. Use `xarray.apply_ufunc()` to apply functions that consume and return NumPy\n",
-    "   arrays.\n",
-    "\n",
-    "3. Use `xarray.map_blocks()`, `Dataset.map_blocks()` or `DataArray.map_blocks()`\n",
-    "   to apply functions that consume and return xarray objects.\n",
-    "\n",
-    "Which method you use ultimately depends on the type of input objects expected by\n",
-    "the function you're wrapping, and the level of performance or convenience you\n",
-    "desire.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eea1312e-449b-4e4f-b083-552d2536f553",
-   "metadata": {},
-   "source": [
-    "## `map_blocks`\n",
-    "\n",
-    "`map_blocks` is inspired by the `dask.array` function of the same name and lets\n",
-    "you map a function on blocks of the xarray object (including Datasets!).\n",
-    "\n",
-    "At _compute_ time, your function will receive an xarray object with concrete\n",
-    "(computed) values along with appropriate metadata. This function should return\n",
-    "an xarray object.\n",
-    "\n",
-    "Here is an example\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2e3f5477-ed1d-4dd4-8d4c-7b4d7943e5a6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def time_mean(obj):\n",
-    "    # use xarray's convenient API here\n",
-    "    # you could convert to a pandas dataframe and use pandas' extensive API\n",
-    "    # or use .plot() and plt.savefig to save visualizations to disk in parallel.\n",
-    "    return obj.mean(\"lat\")\n",
-    "\n",
-    "\n",
-    "ds.map_blocks(time_mean)  # this is lazy!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0f90ad7-9d0f-450f-b422-ea26c9d765b1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# this will calculate values and will return True if the computation works as expected\n",
-    "ds.map_blocks(time_mean).identical(ds.mean(\"lat\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0062395a-5a91-41e5-a767-1d3f895fde7f",
-   "metadata": {},
-   "source": [
-    "### Exercise\n",
-    "\n",
-    "Try applying the following function with `map_blocks`. Specify `scale` as an\n",
-    "argument and `offset` as a kwarg.\n",
-    "\n",
-    "The docstring should help:\n",
-    "https://xarray.pydata.org/en/stable/generated/xarray.map_blocks.html\n",
-    "\n",
-    "```\n",
-    "def time_mean_scaled(obj, scale, offset):\n",
-    "    return obj.mean(\"lat\") * scale + offset\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "839a8dd4-50ca-46e6-90b4-8776911c175a",
-   "metadata": {},
-   "source": [
-    "### More advanced functions\n",
-    "\n",
-    "`map_blocks` needs to know what the returned object looks like _exactly_. It\n",
-    "does so by passing a 0-shaped xarray object to the function and examining the\n",
-    "result. This approach cannot work in all cases For such advanced use cases,\n",
-    "`map_blocks` allows a `template` kwarg. See\n",
-    "https://xarray.pydata.org/en/latest/dask.html#map-blocks for more details\n"
    ]
   },
   {

--- a/advanced/apply_ufunc/simple_dask_apply_ufunc.ipynb
+++ b/advanced/apply_ufunc/simple_dask_apply_ufunc.ipynb
@@ -39,6 +39,53 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e511efdf-1f39-4dcf-a111-660eeca2eb8c",
+   "metadata": {},
+   "source": [
+    "First lets set up a `LocalCluster` using [dask.distributed](https://distributed.dask.org/).\n",
+    "\n",
+    "You can use any kind of dask cluster. This step is completely independent of\n",
+    "xarray. While not strictly necessary, the dashboard provides a nice learning\n",
+    "tool.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba5df0bd-4fa2-43b2-942c-fb6ce2a55d6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "\n",
+    "client = Client()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aa9663b-028a-4639-be90-5576f88d1bfa",
+   "metadata": {},
+   "source": [
+    "<p>&#128070</p> Click the Dashboard link above. Or click the \"Search\" button in the dashboard.\n",
+    "\n",
+    "Let's test that the dashboard is working..\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4419e2a6-9ff7-4d33-b6da-243210c34a37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.array\n",
+    "\n",
+    "dask.array.ones((1000, 4), chunks=(2, 1)).compute()  # should see activity in dashboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e6abae80-004a-481f-9b1a-c476de951ef0",
    "metadata": {},
    "source": [
@@ -261,6 +308,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b375c8a-b7ef-47a6-b007-1fc2f34a2cf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "71492531-4eda-4c47-86e5-dad033c22751",
    "metadata": {},
@@ -269,16 +326,6 @@
     "\n",
     "1. https://xarray.pydata.org/en/stable/examples/apply_ufunc_vectorize_1d.html#\n",
     "2. https://docs.dask.org/en/latest/array-best-practices.html\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b375c8a-b7ef-47a6-b007-1fc2f34a2cf5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client.close()"
    ]
   }
  ],

--- a/advanced/apply_ufunc/simple_dask_apply_ufunc.ipynb
+++ b/advanced/apply_ufunc/simple_dask_apply_ufunc.ipynb
@@ -7,9 +7,20 @@
    "source": [
     "<img src=\"http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png\" align=\"right\" width=\"30%\">\n",
     "\n",
-    "<a id='applymap'></a>\n",
+    "# Handling dask arrays\n",
     "\n",
-    "# A gentle introduction\n",
+    "`apply_ufunc` is a more advanced wrapper that is designed to apply functions\n",
+    "that expect and return NumPy (or other arrays). For example, this would include\n",
+    "all of SciPy's API. Since `apply_ufunc` operates on lower-level NumPy or Dask\n",
+    "objects, it skips the overhead of using Xarray objects making it a good choice\n",
+    "for performance-critical functions.\n",
+    "\n",
+    "`apply_ufunc` can be a little tricky to get right since it operates at a lower\n",
+    "level than `map_blocks`. On the other hand, Xarray uses `apply_ufunc` internally\n",
+    "to implement much of its API, meaning that it is quite powerful!\n",
+    "\n",
+    "Learning goals:\n",
+    "- Learn that `apply_ufunc` automates aspects of applying computation functions that are designed for pure arrays (like numpy arrays) on xarray objects\n",
     "\n",
     "## Setup"
    ]
@@ -27,53 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "564018be-0815-4996-a479-890e2f2a0ec3",
-   "metadata": {},
-   "source": [
-    "First lets set up a `LocalCluster` using [dask.distributed](https://distributed.dask.org/).\n",
-    "\n",
-    "You can use any kind of dask cluster. This step is completely independent of\n",
-    "xarray. While not strictly necessary, the dashboard provides a nice learning\n",
-    "tool.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8813a53f-fab8-43e8-9b3b-3b90dcc96ac2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from dask.distributed import Client\n",
-    "\n",
-    "client = Client()\n",
-    "client"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0137c60c-2ecf-4f04-94fa-42da68418791",
-   "metadata": {},
-   "source": [
-    "<p>&#128070</p> Click the Dashboard link above. Or click the \"Search\" button in the dashboard.\n",
-    "\n",
-    "Let's test that the dashboard is working..\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e06e3696-3b26-4475-aa1a-4e4dc9c9f344",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import dask.array\n",
-    "\n",
-    "dask.array.ones((1000, 4), chunks=(2, 1)).compute()  # should see activity in dashboard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "e6abae80-004a-481f-9b1a-c476de951ef0",
    "metadata": {},
    "source": [
@@ -87,33 +51,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.tutorial.open_dataset(\n",
-    "    \"air_temperature\",\n",
-    "    chunks={  # this tells xarray to open the dataset as a dask array\n",
-    "        \"lat\": 25,\n",
-    "        \"lon\": 25,\n",
-    "        \"time\": -1,\n",
-    "    },\n",
-    ")\n",
+    "ds = xr.tutorial.load_dataset(\"air_temperature\", chunks={\"time\": 100})\n",
     "ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5cf98cf4-1d3f-4ef7-9dcb-f30ade01e458",
-   "metadata": {},
-   "source": [
-    "## apply_ufunc\n",
-    "\n",
-    "`apply_ufunc` is a more advanced wrapper that is designed to apply functions\n",
-    "that expect and return NumPy (or other arrays). For example, this would include\n",
-    "all of SciPy's API. Since `apply_ufunc` operates on lower-level NumPy or Dask\n",
-    "objects, it skips the overhead of using Xarray objects making it a good choice\n",
-    "for performance-critical functions.\n",
-    "\n",
-    "`apply_ufunc` can be a little tricky to get right since it operates at a lower\n",
-    "level than `map_blocks`. On the other hand, Xarray uses `apply_ufunc` internally\n",
-    "to implement much of its API, meaning that it is quite powerful!\n"
    ]
   },
   {
@@ -121,10 +60,10 @@
    "id": "a6b21b09-3ebb-4efb-9c57-44bf587ba92d",
    "metadata": {},
    "source": [
-    "### A simple example\n",
+    "## A simple example\n",
     "\n",
     "Simple functions that act independently on each value should work without any\n",
-    "additional arguments. However `dask` handling needs to be explicitly enabled\n"
+    "additional arguments. "
    ]
   },
   {
@@ -140,7 +79,10 @@
    "source": [
     "# Expect an error here\n",
     "\n",
-    "squared_error = lambda x, y: (x - y) ** 2\n",
+    "\n",
+    "def squared_error(x, y):\n",
+    "    return (x - y) ** 2\n",
+    "\n",
     "\n",
     "xr.apply_ufunc(squared_error, ds.air, 1)"
    ]

--- a/advanced/apply_ufunc/simple_dask_apply_ufunc.ipynb
+++ b/advanced/apply_ufunc/simple_dask_apply_ufunc.ipynb
@@ -32,6 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import dask\n",
     "import numpy as np\n",
     "import xarray as xr"
    ]
@@ -41,7 +42,7 @@
    "id": "e6abae80-004a-481f-9b1a-c476de951ef0",
    "metadata": {},
    "source": [
-    "Let's load a dataset"
+    "Let's open a dataset. We specify `chunks` so that we create a dask arrays for the DataArrays"
    ]
   },
   {
@@ -51,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.tutorial.load_dataset(\"air_temperature\", chunks={\"time\": 100})\n",
+    "ds = xr.tutorial.open_dataset(\"air_temperature\", chunks={\"time\": 100})\n",
     "ds"
    ]
   },
@@ -62,8 +63,9 @@
    "source": [
     "## A simple example\n",
     "\n",
-    "Simple functions that act independently on each value should work without any\n",
-    "additional arguments. "
+    "All the concepts from applying numpy functions carry over.\n",
+    "\n",
+    "However the handling of dask arrays needs to be explicitly activated."
    ]
   },
   {
@@ -78,8 +80,6 @@
    "outputs": [],
    "source": [
     "# Expect an error here\n",
-    "\n",
-    "\n",
     "def squared_error(x, y):\n",
     "    return (x - y) ** 2\n",
     "\n",
@@ -123,15 +123,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1418c06-e1f8-4db8-bdf5-a4e23f6524e1",
+   "metadata": {},
+   "source": [
+    "Let's again use the wrapper trick to understand what `squared_error` receives.\n",
+    "\n",
+    "We see that it receives a dask array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d9a5eb4-c6e9-445f-87bb-5bcaa653439f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wrapper(x, y):\n",
+    "    print(f\"received x of type {type(x)}, shape {x.shape}\")\n",
+    "    print(f\"received y of type {type(y)}\")\n",
+    "    return squared_error(x, y)\n",
+    "\n",
+    "\n",
+    "xr.apply_ufunc(wrapper, ds.air, 1, dask=\"allowed\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ce1b0d1c-8bf3-4ddb-aa5f-e2ca70415ad6",
    "metadata": {},
    "source": [
-    "### A more complicated example with a dask-aware function\n",
+    "## Reductions and core dimensions\n",
+    "\n",
+    "`squared_error` operated on a per-element basis. How about a reduction like `np.mean`?\n",
+    "\n",
+    "Such functions involve the concept of \"core dimensions\". One way to think about core dimensions is to consider the smallest dimensionality of data necessary to apply the function.\n",
     "\n",
     "For using more complex operations that consider some array values collectively,\n",
-    "it’s important to understand the idea of **core dimensions** from NumPy’s\n",
-    "generalized ufuncs. Core dimensions are defined as dimensions that should not be\n",
-    "broadcast over. Usually, they correspond to the fundamental dimensions over\n",
+    "it’s important to understand the idea of **core dimensions**. \n",
+    "Usually, they correspond to the fundamental dimensions over\n",
     "which an operation is defined, e.g., the summed axis in `np.sum`. A good clue\n",
     "that core dimensions are needed is the presence of an `axis` argument on the\n",
     "corresponding NumPy function.\n",
@@ -166,6 +195,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7952ceb1-8402-41d1-8813-31228c3e9ae6",
+   "metadata": {},
+   "source": [
+    "Again, this identical to the built-in `mean`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "6c343d01-cdf6-4e48-a349-606f06c4c251",
@@ -180,7 +217,7 @@
    "id": "8abf7aa7-e1e6-4935-9d59-58d4f587135c",
    "metadata": {},
    "source": [
-    "### Automatically parallelizing dask-unaware functions\n",
+    "## Automatically parallelizing dask-unaware functions\n",
     "\n",
     "A very useful `apply_ufunc` feature is the ability to apply arbitrary functions\n",
     "in parallel to each block. This ability can be activated using\n",
@@ -189,7 +226,9 @@
     "be necessary.\n",
     "\n",
     "We will use `scipy.integrate.trapz` as an example of a function that cannot\n",
-    "handle dask arrays and requires a core dimension.\n"
+    "handle dask arrays and requires a core dimension. If we call `trapz` with a dask\n",
+    "array, we get a numpy array back that is, the values have been eagerly computed.\n",
+    "This is undesirable behaviour\n"
    ]
   },
   {
@@ -202,19 +241,23 @@
     "import scipy as sp\n",
     "import scipy.integrate\n",
     "\n",
-    "sp.integrate.trapz(ds.air.data)  # does NOT return a dask array"
+    "sp.integrate.trapz(ds.air.data, axis=ds.air.get_axis_num(\"lon\"))  # does NOT return a dask array"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "f62f8f73-cd7f-45fe-b379-6e9b675d38a0",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8faef8dd-13b0-46c6-a19a-08e5e095fd4c",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "#### Exercise\n",
-    "\n",
-    "Use `apply_ufunc` to apply `sp.integrate.trapz` along the `time` axis so that\n",
-    "you get a dask array returned. You will need to specify `dask=\"parallelized\"`\n",
-    "and `output_dtypes` (a list of `dtypes` per returned variable).\n"
+    "xr.apply_ufunc(\n",
+    "    sp.integrate.trapz,\n",
+    "    ds,\n",
+    "    input_core_dims=[[\"lon\"]],\n",
+    "    kwargs={\"axis\": -1},\n",
+    "    dask=\"parallelized\",\n",
+    ")"
    ]
   },
   {

--- a/advanced/apply_ufunc/simple_numpy_apply_ufunc.ipynb
+++ b/advanced/apply_ufunc/simple_numpy_apply_ufunc.ipynb
@@ -1,0 +1,503 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7a8ff28a-4be3-469f-8cf4-9297e71cc4ca",
+   "metadata": {},
+   "source": [
+    "<img src=\"http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png\" align=\"right\" width=\"30%\">\n",
+    "\n",
+    "# A gentle introduction\n",
+    "\n",
+    "`apply_ufunc` is a more advanced wrapper that is designed to apply functions\n",
+    "that expect and return NumPy (or other arrays). For example, this would include\n",
+    "all of SciPy's API. Since `apply_ufunc` operates on lower-level NumPy or Dask\n",
+    "objects, it skips the overhead of using Xarray objects making it a good choice\n",
+    "for performance-critical functions. Xarray uses `apply_ufunc` internally\n",
+    "to implement much of its API, meaning that it is quite powerful!\n",
+    "\n",
+    "Learning goals:\n",
+    "- Learn that `apply_ufunc` automates aspects of applying computation functions that are designed for pure arrays (like numpy arrays) on xarray objects\n",
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32335e2d-9f8c-490d-a991-2bcabbdf3d16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "\n",
+    "xr.set_options(display_expand_data=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6abae80-004a-481f-9b1a-c476de951ef0",
+   "metadata": {},
+   "source": [
+    "Let's load a dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b74da273-e603-442f-9970-ef3eb17a3ad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.tutorial.load_dataset(\"air_temperature\")\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b21b09-3ebb-4efb-9c57-44bf587ba92d",
+   "metadata": {},
+   "source": [
+    "## A simple example\n",
+    "\n",
+    "Simple functions that act independently on each value should work without any\n",
+    "additional arguments. \n",
+    "\n",
+    "Consider the following `squared_error` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26800228-97cc-4f35-baf8-a5face577543",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def squared_error(x, y):\n",
+    "    return (x - y) ** 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bee21ef-be9e-4393-82cf-e0fc6fe8d97e",
+   "metadata": {},
+   "source": [
+    "We can apply this manually by extracting the underlying numpy array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69dfcefd-1720-4315-96e0-eca7cc32a3c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numpy_result = squared_error(ds.air.data, 1)\n",
+    "numpy_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b001bf4-1e7c-4c34-8ff3-81b18c65cf5d",
+   "metadata": {},
+   "source": [
+    "To convert this result to a DataArray, we could do it manually"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73fc3c08-6015-4f08-97cd-4e431229c9c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.DataArray(data=numpy_result, dims=ds.air.dims, coords=ds.air.coords)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "110f7456-a52b-4ce9-b779-f9f542a427c4",
+   "metadata": {},
+   "source": [
+    "A shorter version uses [DataArray.copy](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.copy.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea78fb57-e142-4db5-8834-1889440c5367",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.air.copy(data=numpy_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "193213d5-5644-4225-8f32-c73a20fa412d",
+   "metadata": {},
+   "source": [
+    "Using `DataArray.copy` works for such simple cases but doesn't generalize that well. For example, consider a function that removed one dimension and added a new dimension.\n",
+    "\n",
+    "`apply_ufunc` can handle such cases. Here's how to use it with `squared_error`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f145c8ca-f559-4005-b51c-c59ee7ebaef7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(squared_error, ds.air, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "007c45dd-b532-41d0-8a28-c35c7448b6ba",
+   "metadata": {},
+   "source": [
+    "## How does apply_ufunc work?\n",
+    "\n",
+    "To illustrate how `apply_ufunc` works, let us write a small wrapper function. This will let us examine what data is received and returned from the applied function. \n",
+    "\n",
+    "```{tip}\n",
+    "This trick is very useful for debugging\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05c0fe6d-e553-4c38-9cf7-9b7e6efab9a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wrapper(x, y):\n",
+    "    print(f\"received x of type {type(x)}, shape {x.shape}\")\n",
+    "    print(f\"received y of type {type(y)}\")\n",
+    "    return squared_error(x, y)\n",
+    "\n",
+    "\n",
+    "xr.apply_ufunc(wrapper, ds.air, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db9bc205-7c0d-4992-bda5-f16486d29361",
+   "metadata": {},
+   "source": [
+    "We see that `wrapper` receives the underlying numpy array (`ds.air.data`), and the integer `1`. \n",
+    "\n",
+    "Essentially, `apply_ufunc` does the following:\n",
+    "1. extracts the underlying array data, \n",
+    "2. passes it to the user function, \n",
+    "3. receives the returned values, and \n",
+    "4. then wraps that back up as an array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79f2c642-b814-48e0-a84c-7f1fb0858c53",
+   "metadata": {},
+   "source": [
+    "apply_ufunc easily handles both dataarrays and datasets. \n",
+    "\n",
+    "When passed a Dataset, apply-ufunc will loop over the data variables and sequentially pass those to `squared_error`. So `squared_error` always receives a numpy array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8faf9e4d-c5e3-4a41-b866-b6f39df04e10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(wrapper, ds, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b658981-db33-4a46-84cc-8c17db68b1e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(squared_error, ds, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac4f4511-2535-4dd8-af2e-085a9f453e9f",
+   "metadata": {},
+   "source": [
+    "## Reductions and core dimensions\n",
+    "\n",
+    "`squared_error` operated on a per-element basis. How about a reduction like `np.mean`?\n",
+    "\n",
+    "Such functions involve the concept of \"core dimensions\". One way to think about core dimensions is to consider the smallest dimensionality of data necessary to apply the function.\n",
+    "\n",
+    "For using more complex operations that consider some array values collectively,\n",
+    "it’s important to understand the idea of **core dimensions**. \n",
+    "Usually, they correspond to the fundamental dimensions over\n",
+    "which an operation is defined, e.g., the summed axis in `np.sum`. A good clue\n",
+    "that core dimensions are needed is the presence of an `axis` argument on the\n",
+    "corresponding NumPy function.\n",
+    "\n",
+    "Let's write a function that computes the mean along `time` for a provided xarray object. This function requires one core dimension `time`. For `ds.air` note that `time` is the 0th axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84856bf9-e926-4b6f-9c38-ef61b2953610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.air.dims"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b075981-c16c-4f0b-a37d-c2dede010ebc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.mean(ds.air, axis=ds.air.get_axis_num(\"time\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2ab71ad-b2ff-4203-a484-0c2d6b2c4be4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.mean(ds.air.data, axis=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "484bc283-a0a8-40f1-906b-81aaf06a14ec",
+   "metadata": {},
+   "source": [
+    "Let's try to use `apply_ufunc` to replicate `np.mean(ds.air.data, axis=0)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f56f265-a723-4165-a248-12f5ba8c34d5",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(\n",
+    "    # function to apply\n",
+    "    np.mean,\n",
+    "    # object with data to pass to function\n",
+    "    ds,\n",
+    "    # keyword arguments to pass to np.mean\n",
+    "    kwargs={\"axis\": 0},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7be1720-b529-444d-852e-a6f63563ac3f",
+   "metadata": {},
+   "source": [
+    "The error here\n",
+    "> applied function returned data with unexpected number of dimensions. Received 2 dimension(s) but expected 3 dimensions with names: ('time', 'lat', 'lon')\n",
+    "\n",
+    "means that while `np.mean` did indeed reduce one dimension, we did not tell `apply_ufunc` that this would happen. That is, we need to specify the core dimensions on the input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "447f79cd-8ee2-416f-9ebe-b1b4317583d0",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(\n",
+    "    np.mean,\n",
+    "    ds,\n",
+    "    # specify core dimensions as a list of lists\n",
+    "    # here 'time' is the core dimension on `ds`\n",
+    "    input_core_dims=[[\"time\"]],\n",
+    "    kwargs={\"axis\": 0},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "534b12aa-8a69-457b-a901-70a2358b0b71",
+   "metadata": {},
+   "source": [
+    "This next error is a little confusing.\n",
+    "\n",
+    "> size of dimension 'lat' on inputs was unexpectedly changed by applied function from 25 to 53. Only dimensions specified in ``exclude_dims`` with xarray.apply_ufunc are allowed to change size.\n",
+    "\n",
+    "\n",
+    "A good trick here is to pass a little wrapper function to `apply_ufunc` instead and inspect the shapes of data received by the wrapper.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "560f3d23-7760-4573-a091-722b8a440fb8",
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def wrapper(array, **kwargs):\n",
+    "    print(f\"received {type(array)} shape: {array.shape}, kwargs: {kwargs}\")\n",
+    "    result = np.mean(array, **kwargs)\n",
+    "    print(f\"result.shape: {result.shape}\")\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "xr.apply_ufunc(\n",
+    "    wrapper,\n",
+    "    ds,\n",
+    "    # specify core dimensions as a list of lists\n",
+    "    # here 'time' is the core dimension on `ds`\n",
+    "    input_core_dims=[[\"time\"]],\n",
+    "    kwargs={\"axis\": 0},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3ba7a3d-5ab4-4b3b-b0d5-1b6ae98e8d7c",
+   "metadata": {},
+   "source": [
+    "Now we see the issue:\n",
+    "\n",
+    "    received <class 'numpy.ndarray'> shape: (25, 53, 2920), kwargs: {'axis': 0}\n",
+    "    result.shape: (53, 2920)\n",
+    "    \n",
+    "The `time` dimension is of size `2920` and is now the last axis of the array but was initially the first axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f2dd2ec-e036-4fb2-888b-8411e88091dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.air.get_axis_num(\"time\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81fe9fe1-83ff-4d60-bbee-fc11ecd4f73a",
+   "metadata": {},
+   "source": [
+    "This illustrates an important concept: **arrays are transposed so that core dimensions are at the end**. \n",
+    "\n",
+    "With `apply_ufunc`, core dimensions are recognized by name, and then moved to\n",
+    "the last dimension of any input arguments before applying the given function.\n",
+    "This means that for functions that accept an `axis` argument, you usually need\n",
+    "to set `axis=-1`\n",
+    "\n",
+    "Such behaviour means that our functions (like `wrapper` or `np.mean`) do not need to know the exact order of dimensions. They can rely on the core dimensions being at the end allowing us to write very general code! \n",
+    "\n",
+    "We can fix our `apply_ufunc` call by specifying `axis=-1` instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c343d01-cdf6-4e48-a349-606f06c4c251",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wrapper(array, **kwargs):\n",
+    "    print(f\"received {type(array)} shape: {array.shape}, kwargs: {kwargs}\")\n",
+    "    result = np.mean(array, **kwargs)\n",
+    "    print(f\"result.shape: {result.shape}\")\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "xr.apply_ufunc(\n",
+    "    wrapper,\n",
+    "    ds,\n",
+    "    input_core_dims=[[\"time\"]],\n",
+    "    kwargs={\"axis\": -1},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f62f8f73-cd7f-45fe-b379-6e9b675d38a0",
+   "metadata": {},
+   "source": [
+    "#### Exercise\n",
+    "\n",
+    "Use `apply_ufunc` to apply `sp.integrate.trapz` along the `time` axis.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e85abfe-51c3-45be-b47b-957f03a3306b",
+   "metadata": {
+    "tags": [
+     "hide-output",
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import scipy as sp\n",
+    "import scipy.integrate\n",
+    "\n",
+    "xr.apply_ufunc(scipy.integrate.trapz, ds, input_core_dims=[[\"time\"]], kwargs={\"axis\": -1})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b375c8a-b7ef-47a6-b007-1fc2f34a2cf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/advanced/apply_ufunc/simple_numpy_apply_ufunc.ipynb
+++ b/advanced/apply_ufunc/simple_numpy_apply_ufunc.ipynb
@@ -451,7 +451,7 @@
    "id": "f62f8f73-cd7f-45fe-b379-6e9b675d38a0",
    "metadata": {},
    "source": [
-    "#### Exercise\n",
+    "## Exercise\n",
     "\n",
     "Use `apply_ufunc` to apply `sp.integrate.trapz` along the `time` axis.\n"
    ]
@@ -472,16 +472,6 @@
     "import scipy.integrate\n",
     "\n",
     "xr.apply_ufunc(scipy.integrate.trapz, ds, input_core_dims=[[\"time\"]], kwargs={\"axis\": -1})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6b375c8a-b7ef-47a6-b007-1fc2f34a2cf5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "client.close()"
    ]
   }
  ],

--- a/advanced/apply_ufunc/vectorize_1d.ipynb
+++ b/advanced/apply_ufunc/vectorize_1d.ipynb
@@ -1,0 +1,649 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Applying unvectorized functions\n",
+    "\n",
+    "**Author** [Deepak Cherian (NCAR)](https://cherian.net)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example will illustrate how to conveniently apply an unvectorized function `func` to xarray objects using `apply_ufunc`. `func` expects 1D numpy arrays and returns a 1D numpy array. Our goal is to coveniently apply this function along a dimension of xarray objects that may or may not wrap dask arrays with a signature.\n",
+    "\n",
+    "We will illustrate this using `np.interp`: \n",
+    "\n",
+    "    Signature: np.interp(x, xp, fp, left=None, right=None, period=None)\n",
+    "    Docstring:\n",
+    "        One-dimensional linear interpolation.\n",
+    "\n",
+    "    Returns the one-dimensional piecewise linear interpolant to a function\n",
+    "    with given discrete data points (`xp`, `fp`), evaluated at `x`.\n",
+    "\n",
+    "and write an `xr_interp` function with signature\n",
+    "\n",
+    "    xr_interp(xarray_object, dimension_name, new_coordinate_to_interpolate_to)\n",
+    "\n",
+    "### Load data\n",
+    "\n",
+    "First lets load an example dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "\n",
+    "xr.set_options(display_style=\"html\")  # fancy HTML repr\n",
+    "\n",
+    "air = (\n",
+    "    xr.tutorial.load_dataset(\"air_temperature\")\n",
+    "    .air.sortby(\"lat\")  # np.interp needs coordinate in ascending order\n",
+    "    .isel(time=slice(4), lon=slice(3))\n",
+    ")  # choose a small subset for convenience\n",
+    "air"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function we will apply is `np.interp` which expects 1D numpy arrays. This functionality is already implemented in xarray so we use that capability to make sure we are not making mistakes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newlat = np.linspace(15, 75, 100)\n",
+    "air.interp(lat=newlat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's define a function that works with one vector of data along `lat` at a time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interp1d_np(data, x, xi):\n",
+    "    return np.interp(xi, x, data)\n",
+    "\n",
+    "\n",
+    "interped = interp1d_np(air.isel(time=0, lon=0), air.lat, newlat)\n",
+    "expected = air.interp(lat=newlat)\n",
+    "\n",
+    "# no errors are raised if values are equal to within floating point precision\n",
+    "np.testing.assert_allclose(expected.isel(time=0, lon=0).values, interped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### No errors are raised so our interpolation is working.\n",
+    "\n",
+    "This function consumes and returns numpy arrays, which means we need to do a lot of work to convert the result back to an xarray object with meaningful metadata. This is where `apply_ufunc` is very useful.\n",
+    "\n",
+    "### `apply_ufunc`\n",
+    "\n",
+    "    Apply a vectorized function for unlabeled arrays on xarray objects.\n",
+    "\n",
+    "    The function will be mapped over the data variable(s) of the input arguments using \n",
+    "    xarray’s standard rules for labeled computation, including alignment, broadcasting, \n",
+    "    looping over GroupBy/Dataset variables, and merging of coordinates.\n",
+    "    \n",
+    "`apply_ufunc` has many capabilities but for simplicity this example will focus on the common task of vectorizing 1D functions over nD xarray objects. We will iteratively build up the right set of arguments to `apply_ufunc` and read through many error messages in doing so."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.isel(time=0, lon=0),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,\n",
+    "    newlat,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`apply_ufunc` needs to know a lot of information about what our function does so that it can reconstruct the outputs. In this case, the size of dimension lat has changed and we need to explicitly specify that this will happen. xarray helpfully tells us that we need to specify the kwarg `exclude_dims`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `exclude_dims`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "```\n",
+    "exclude_dims : set, optional\n",
+    "        Core dimensions on the inputs to exclude from alignment and\n",
+    "        broadcasting entirely. Any input coordinates along these dimensions\n",
+    "        will be dropped. Each excluded dimension must also appear in\n",
+    "        ``input_core_dims`` for at least one argument. Only dimensions listed\n",
+    "        here are allowed to change size between input and output objects.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.isel(time=0, lon=0),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,\n",
+    "    newlat,\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be set!\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Core dimensions\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Core dimensions are central to using `apply_ufunc`. In our case, our function expects to receive a 1D vector along `lat` &#x2014; this is the dimension that is \"core\" to the function's functionality. Multiple core dimensions are possible. `apply_ufunc` needs to know which dimensions of each variable are core dimensions.\n",
+    "\n",
+    "    input_core_dims : Sequence[Sequence], optional\n",
+    "        List of the same length as ``args`` giving the list of core dimensions\n",
+    "        on each input argument that should not be broadcast. By default, we\n",
+    "        assume there are no core dimensions on any input arguments.\n",
+    "\n",
+    "        For example, ``input_core_dims=[[], ['time']]`` indicates that all\n",
+    "        dimensions on the first argument and all dimensions other than 'time'\n",
+    "        on the second argument should be broadcast.\n",
+    "\n",
+    "        Core dimensions are automatically moved to the last axes of input\n",
+    "        variables before applying ``func``, which facilitates using NumPy style\n",
+    "        generalized ufuncs [2]_.\n",
+    "        \n",
+    "    output_core_dims : List[tuple], optional\n",
+    "        List of the same length as the number of output arguments from\n",
+    "        ``func``, giving the list of core dimensions on each output that were\n",
+    "        not broadcast on the inputs. By default, we assume that ``func``\n",
+    "        outputs exactly one array, with axes corresponding to each broadcast\n",
+    "        dimension.\n",
+    "\n",
+    "        Core dimensions are assumed to appear as the last dimensions of each\n",
+    "        output in the provided order.\n",
+    "        \n",
+    "Next we specify `\"lat\"` as `input_core_dims` on both `air` and `air.lat`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.isel(time=0, lon=0),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,\n",
+    "    newlat,\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], []],\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be set!\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "xarray is telling us that it expected to receive back a numpy array with 0 dimensions but instead received an array with 1 dimension corresponding to `newlat`. We can fix this by specifying `output_core_dims`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.isel(time=0, lon=0),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,\n",
+    "    newlat,\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], []],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"lat\"]],\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be set!\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we get some output! Let's check that this is right\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interped = xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.isel(time=0, lon=0),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,\n",
+    "    newlat,\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], []],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"lat\"]],\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be set!\n",
+    ")\n",
+    "interped[\"lat\"] = newlat  # need to add this manually\n",
+    "xr.testing.assert_allclose(expected.isel(time=0, lon=0), interped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "No errors are raised so it is right!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Vectorization with `np.vectorize`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now our function currently only works on one vector of data which is not so useful given our 3D dataset.\n",
+    "Let's try passing the whole dataset. We add a `print` statement so we can see what our function receives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interp1d_np(data, x, xi):\n",
+    "    print(f\"data: {data.shape} | x: {x.shape} | xi: {xi.shape}\")\n",
+    "    return np.interp(xi, x, data)\n",
+    "\n",
+    "\n",
+    "interped = xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.isel(lon=slice(3), time=slice(4)),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,\n",
+    "    newlat,\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], []],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"lat\"]],\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be set!\n",
+    ")\n",
+    "interped[\"lat\"] = newlat  # need to add this manually\n",
+    "xr.testing.assert_allclose(expected.isel(time=0, lon=0), interped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's a hard-to-interpret error but our `print` call helpfully printed the shapes of the input data: \n",
+    "\n",
+    "    data: (10, 53, 25) | x: (25,) | xi: (100,)\n",
+    "\n",
+    "We see that `air` has been passed as a 3D numpy array which is not what `np.interp` expects. Instead we want loop over all combinations of `lon` and `time`; and apply our function to each corresponding vector of data along `lat`.\n",
+    "`apply_ufunc` makes this easy by specifying `vectorize=True`:\n",
+    "\n",
+    "    vectorize : bool, optional\n",
+    "        If True, then assume ``func`` only takes arrays defined over core\n",
+    "        dimensions as input and vectorize it automatically with\n",
+    "        :py:func:`numpy.vectorize`. This option exists for convenience, but is\n",
+    "        almost always slower than supplying a pre-vectorized function.\n",
+    "        Using this option requires NumPy version 1.12 or newer.\n",
+    "        \n",
+    "Also see the documentation for `np.vectorize`: https://docs.scipy.org/doc/numpy/reference/generated/numpy.vectorize.html. Most importantly\n",
+    "\n",
+    "    The vectorize function is provided primarily for convenience, not for performance. \n",
+    "    The implementation is essentially a for loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interp1d_np(data, x, xi):\n",
+    "    print(f\"data: {data.shape} | x: {x.shape} | xi: {xi.shape}\")\n",
+    "    return np.interp(xi, x, data)\n",
+    "\n",
+    "\n",
+    "interped = xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air,  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,  # as above\n",
+    "    newlat,  # as above\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], []],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"lat\"]],  # returned data has one dimension\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be set!\n",
+    "    vectorize=True,  # loop over non-core dims\n",
+    ")\n",
+    "interped[\"lat\"] = newlat  # need to add this manually\n",
+    "xr.testing.assert_allclose(expected, interped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This unfortunately is another cryptic error from numpy. \n",
+    "\n",
+    "Notice that `newlat` is not an xarray object. Let's add a dimension name `new_lat` and modify the call. Note this cannot be `lat` because xarray expects dimensions to be the same size (or broadcastable) among all inputs. `output_core_dims` needs to be modified appropriately. We'll manually rename `new_lat` back to `lat` for easy checking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interp1d_np(data, x, xi):\n",
+    "    print(f\"data: {data.shape} | x: {x.shape} | xi: {xi.shape}\")\n",
+    "    return np.interp(xi, x, data)\n",
+    "\n",
+    "\n",
+    "interped = xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air,  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,  # as above\n",
+    "    newlat,  # as above\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], [\"new_lat\"]],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"new_lat\"]],  # returned data has one dimension\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be a set!\n",
+    "    vectorize=True,  # loop over non-core dims\n",
+    ")\n",
+    "interped = interped.rename({\"new_lat\": \"lat\"})\n",
+    "interped[\"lat\"] = newlat  # need to add this manually\n",
+    "xr.testing.assert_allclose(\n",
+    "    expected.transpose(*interped.dims), interped  # order of dims is different\n",
+    ")\n",
+    "interped"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the printed input shapes are all 1D and correspond to one vector along the `lat` dimension.\n",
+    "\n",
+    "The result is now an xarray object with coordinate values copied over from `data`. This is why `apply_ufunc` is so convenient; it takes care of a lot of boilerplate necessary to apply functions that consume and produce numpy arrays to xarray objects.\n",
+    "\n",
+    "One final point: `lat` is now the *last* dimension in `interped`. This is a \"property\" of core dimensions: they are moved to the end before being sent to `interp1d_np` as was noted in the docstring for `input_core_dims`\n",
+    "\n",
+    "        Core dimensions are automatically moved to the last axes of input\n",
+    "        variables before applying ``func``, which facilitates using NumPy style\n",
+    "        generalized ufuncs [2]_."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parallelization with dask\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So far our function can only handle numpy arrays. A real benefit of `apply_ufunc` is the ability to easily parallelize over dask chunks _when needed_. \n",
+    "\n",
+    "We want to apply this function in a vectorized fashion over each chunk of the dask array. This is possible using dask's `blockwise`, `map_blocks`, or `apply_gufunc`. Xarray's `apply_ufunc` wraps dask's `apply_gufunc` and asking it to map the function over chunks using `apply_gufunc` is as simple as specifying `dask=\"parallelized\"`. With this level of flexibility we need to provide dask with some extra information: \n",
+    "  1. `output_dtypes`: dtypes of all returned objects, and \n",
+    "  2. `output_sizes`: lengths of any new dimensions. \n",
+    "  \n",
+    "Here we need to specify `output_dtypes` since `apply_ufunc` can infer the size of the new dimension `new_lat` from the argument corresponding to the third element in `input_core_dims`. Here I choose the chunk sizes to illustrate that `np.vectorize` is still applied so that our function receives 1D vectors even though the blocks are 3D."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interp1d_np(data, x, xi):\n",
+    "    print(f\"data: {data.shape} | x: {x.shape} | xi: {xi.shape}\")\n",
+    "    return np.interp(xi, x, data)\n",
+    "\n",
+    "\n",
+    "interped = xr.apply_ufunc(\n",
+    "    interp1d_np,  # first the function\n",
+    "    air.chunk({\"time\": 2, \"lon\": 2}),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,  # as above\n",
+    "    newlat,  # as above\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], [\"new_lat\"]],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"new_lat\"]],  # returned data has one dimension\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be a set!\n",
+    "    vectorize=True,  # loop over non-core dims\n",
+    "    dask=\"parallelized\",\n",
+    "    output_dtypes=[air.dtype],  # one per output\n",
+    ").rename({\"new_lat\": \"lat\"})\n",
+    "interped[\"lat\"] = newlat  # need to add this manually\n",
+    "xr.testing.assert_allclose(expected.transpose(*interped.dims), interped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Yay! our function is receiving 1D vectors, so we've successfully parallelized applying a 1D function over a block. If you have a distributed dashboard up, you should see computes happening as equality is checked.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### High performance vectorization: gufuncs, numba & guvectorize\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`np.vectorize` is a very convenient function but is unfortunately slow. It is only marginally faster than writing a for loop in Python and looping. A common way to get around this is to write a base interpolation function that can handle nD arrays in a compiled language like Fortran and then pass that to `apply_ufunc`.\n",
+    "\n",
+    "Another option is to use the numba package which provides a very convenient `guvectorize` decorator: https://numba.pydata.org/numba-doc/latest/user/vectorize.html#the-guvectorize-decorator\n",
+    "\n",
+    "Any decorated function gets compiled and will loop over any non-core dimension in parallel when necessary. We need to specify some extra information:\n",
+    "\n",
+    "   1. Our function cannot return a variable any more. Instead it must receive a variable (the last argument) whose contents the function will modify. So we change from `def interp1d_np(data, x, xi)` to `def interp1d_np_gufunc(data, x, xi, out)`. Our computed results must be assigned to `out`. All values of `out` must be assigned explicitly.\n",
+    "   \n",
+    "   2. `guvectorize` needs to know the dtypes of the input and output. This is specified in string form as the first argument. Each element of the tuple corresponds to each argument of the function. In this case, we specify `float64` for all inputs and outputs: `\"(float64[:], float64[:], float64[:], float64[:])\"` corresponding to `data, x, xi, out`\n",
+    "   \n",
+    "   3. Now we need to tell numba the size of the dimensions the function takes as inputs and returns as output i.e. core dimensions. This is done in symbolic form i.e. `data` and `x` are vectors of the same length, say `n`; `xi` and the output `out` have a different length, say `m`. So the second argument is (again as a string)\n",
+    "         `\"(n), (n), (m) -> (m).\"` corresponding again to `data, x, xi, out`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numba import float64, guvectorize\n",
+    "\n",
+    "\n",
+    "@guvectorize(\"(float64[:], float64[:], float64[:], float64[:])\", \"(n), (n), (m) -> (m)\")\n",
+    "def interp1d_np_gufunc(data, x, xi, out):\n",
+    "    # numba doesn't really like this.\n",
+    "    # seem to support fstrings so do it the old way\n",
+    "    print(\"data: \" + str(data.shape) + \" | x:\" + str(x.shape) + \" | xi: \" + str(xi.shape))\n",
+    "    out[:] = np.interp(xi, x, data)\n",
+    "    # gufuncs don't return data\n",
+    "    # instead you assign to a the last arg\n",
+    "    # return np.interp(xi, x, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The warnings are about object-mode compilation relating to the `print` statement. This means we don't get much speed up: https://numba.pydata.org/numba-doc/latest/user/performance-tips.html#no-python-mode-vs-object-mode. We'll keep the `print` statement temporarily to make sure that `guvectorize` acts like we want it to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interped = xr.apply_ufunc(\n",
+    "    interp1d_np_gufunc,  # first the function\n",
+    "    air.chunk({\"time\": 2, \"lon\": 2}),  # now arguments in the order expected by 'interp1_np'\n",
+    "    air.lat,  # as above\n",
+    "    newlat,  # as above\n",
+    "    input_core_dims=[[\"lat\"], [\"lat\"], [\"new_lat\"]],  # list with one entry per arg\n",
+    "    output_core_dims=[[\"new_lat\"]],  # returned data has one dimension\n",
+    "    exclude_dims=set((\"lat\",)),  # dimensions allowed to change size. Must be a set!\n",
+    "    # vectorize=True,  # not needed since numba takes care of vectorizing\n",
+    "    dask=\"parallelized\",\n",
+    "    output_dtypes=[air.dtype],  # one per output\n",
+    ").rename({\"new_lat\": \"lat\"})\n",
+    "interped[\"lat\"] = newlat  # need to add this manually\n",
+    "xr.testing.assert_allclose(expected.transpose(*interped.dims), interped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Yay! Our function is receiving 1D vectors and is working automatically with dask arrays. Finally let's comment out the print line and wrap everything up in a nice reusable function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numba import float64, guvectorize\n",
+    "\n",
+    "\n",
+    "@guvectorize(\n",
+    "    \"(float64[:], float64[:], float64[:], float64[:])\",\n",
+    "    \"(n), (n), (m) -> (m)\",\n",
+    "    nopython=True,\n",
+    ")\n",
+    "def interp1d_np_gufunc(data, x, xi, out):\n",
+    "    out[:] = np.interp(xi, x, data)\n",
+    "\n",
+    "\n",
+    "def xr_interp(data, dim, newdim):\n",
+    "\n",
+    "    interped = xr.apply_ufunc(\n",
+    "        interp1d_np_gufunc,  # first the function\n",
+    "        data,  # now arguments in the order expected by 'interp1_np'\n",
+    "        data[dim],  # as above\n",
+    "        newdim,  # as above\n",
+    "        input_core_dims=[[dim], [dim], [\"__newdim__\"]],  # list with one entry per arg\n",
+    "        output_core_dims=[[\"__newdim__\"]],  # returned data has one dimension\n",
+    "        exclude_dims=set((dim,)),  # dimensions allowed to change size. Must be a set!\n",
+    "        # vectorize=True,  # not needed since numba takes care of vectorizing\n",
+    "        dask=\"parallelized\",\n",
+    "        output_dtypes=[data.dtype],  # one per output; could also be float or np.dtype(\"float64\")\n",
+    "    ).rename({\"__newdim__\": dim})\n",
+    "    interped[dim] = newdim  # need to add this manually\n",
+    "\n",
+    "    return interped\n",
+    "\n",
+    "\n",
+    "xr.testing.assert_allclose(\n",
+    "    expected.transpose(*interped.dims),\n",
+    "    xr_interp(air.chunk({\"time\": 2, \"lon\": 2}), \"lat\", newlat),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This technique is generalizable to any 1D function."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  },
+  "nbsphinx": {
+   "allow_errors": true
+  },
+  "org": null,
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/advanced/apply_ufunc/vectorize_1d.ipynb
+++ b/advanced/apply_ufunc/vectorize_1d.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Applying unvectorized functions\n",
+    "# Applying unvectorized functions\n",
     "\n",
     "**Author** [Deepak Cherian (NCAR)](https://cherian.net)"
    ]
@@ -28,7 +28,7 @@
     "\n",
     "    xr_interp(xarray_object, dimension_name, new_coordinate_to_interpolate_to)\n",
     "\n",
-    "### Load data\n",
+    "## Load data\n",
     "\n",
     "First lets load an example dataset"
    ]
@@ -97,11 +97,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### No errors are raised so our interpolation is working.\n",
+    "No errors are raised so our interpolation is working.\n",
     "\n",
     "This function consumes and returns numpy arrays, which means we need to do a lot of work to convert the result back to an xarray object with meaningful metadata. This is where `apply_ufunc` is very useful.\n",
     "\n",
-    "### `apply_ufunc`\n",
+    "## `apply_ufunc`\n",
     "\n",
     "    Apply a vectorized function for unlabeled arrays on xarray objects.\n",
     "\n",
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `exclude_dims`"
+    "## `exclude_dims`"
    ]
   },
   {
@@ -182,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Core dimensions\n",
+    "## Core dimensions\n",
     "\n"
    ]
   },
@@ -300,7 +300,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Vectorization with `np.vectorize`"
+    "## Vectorization with `np.vectorize`"
    ]
   },
   {
@@ -449,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Parallelization with dask\n",
+    "## Parallelization with dask\n",
     "\n"
    ]
   },
@@ -505,7 +505,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### High performance vectorization: gufuncs, numba & guvectorize\n",
+    "## High performance vectorization: gufuncs, numba & guvectorize\n",
     "\n"
    ]
   },

--- a/advanced/apply_ufunc/vectorize_1d.ipynb
+++ b/advanced/apply_ufunc/vectorize_1d.ipynb
@@ -115,7 +115,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "xr.apply_ufunc(\n",
@@ -158,7 +162,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "xr.apply_ufunc(\n",
@@ -213,7 +221,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "xr.apply_ufunc(\n",
@@ -302,7 +314,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "def interp1d_np(data, x, xi):\n",
@@ -350,7 +366,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
    "outputs": [],
    "source": [
     "def interp1d_np(data, x, xi):\n",

--- a/advanced/map_blocks/map_blocks.md
+++ b/advanced/map_blocks/map_blocks.md
@@ -1,0 +1,5 @@
+# map_blocks
+
+```{tableofcontents}
+
+```

--- a/advanced/map_blocks/simple_map_blocks.ipynb
+++ b/advanced/map_blocks/simple_map_blocks.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "32a33add-8107-4f88-b831-7d24d76b2a98",
+   "metadata": {},
+   "source": [
+    "# A gentle introduction\n",
+    "\n",
+    "`map_blocks` is inspired by the `dask.array` function of the same name and lets\n",
+    "you map a function on blocks of the xarray object (including Datasets!).\n",
+    "\n",
+    "At _compute_ time, your function will receive an xarray object with concrete\n",
+    "(computed) values along with appropriate metadata. This function should return\n",
+    "an xarray object.\n",
+    "\n",
+    "Here is an example\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "780fe5ac-6c28-4db5-b277-bea05673f23f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def time_mean(obj):\n",
+    "    # use xarray's convenient API here\n",
+    "    # you could convert to a pandas dataframe and use pandas' extensive API\n",
+    "    # or use .plot() and plt.savefig to save visualizations to disk in parallel.\n",
+    "    return obj.mean(\"lat\")\n",
+    "\n",
+    "\n",
+    "ds.map_blocks(time_mean)  # this is lazy!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d95d30c3-bb12-48b0-8d84-6b2e2d1532f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this will calculate values and will return True if the computation works as expected\n",
+    "ds.map_blocks(time_mean).identical(ds.mean(\"lat\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "037529cc-f326-4bc1-bcec-932943b7c54b",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "\n",
+    "Try applying the following function with `map_blocks`. Specify `scale` as an\n",
+    "argument and `offset` as a kwarg.\n",
+    "\n",
+    "The docstring should help:\n",
+    "https://xarray.pydata.org/en/stable/generated/xarray.map_blocks.html\n",
+    "\n",
+    "```\n",
+    "def time_mean_scaled(obj, scale, offset):\n",
+    "    return obj.mean(\"lat\") * scale + offset\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccab2fa5-5ce8-4bae-8e15-67e68fb55ccd",
+   "metadata": {},
+   "source": [
+    "### More advanced functions\n",
+    "\n",
+    "`map_blocks` needs to know what the returned object looks like _exactly_. It\n",
+    "does so by passing a 0-shaped xarray object to the function and examining the\n",
+    "result. This approach cannot work in all cases For such advanced use cases,\n",
+    "`map_blocks` allows a `template` kwarg. See\n",
+    "https://xarray.pydata.org/en/latest/dask.html#map-blocks for more details\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/advanced/map_blocks/simple_map_blocks.ipynb
+++ b/advanced/map_blocks/simple_map_blocks.ipynb
@@ -3,8 +3,13 @@
   {
    "cell_type": "markdown",
    "id": "32a33add-8107-4f88-b831-7d24d76b2a98",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
+    "<img src=\"http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png\" align=\"right\" width=\"30%\">\n",
+    "\n",
+    "\n",
     "# A gentle introduction\n",
     "\n",
     "`map_blocks` is inspired by the `dask.array` function of the same name and lets\n",
@@ -12,9 +17,103 @@
     "\n",
     "At _compute_ time, your function will receive an xarray object with concrete\n",
     "(computed) values along with appropriate metadata. This function should return\n",
-    "an xarray object.\n",
+    "an xarray object.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8418c5da-3605-4bed-8582-7714318be228",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e5f4844-8b33-4c9e-aa73-de60c1dc1f03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "import numpy as np\n",
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f26cd492-3d7e-4095-ba50-39db83ebc212",
+   "metadata": {},
+   "source": [
+    "First lets set up a `LocalCluster` using [dask.distributed](https://distributed.dask.org/).\n",
     "\n",
-    "Here is an example\n"
+    "You can use any kind of dask cluster. This step is completely independent of\n",
+    "xarray. While not strictly necessary, the dashboard provides a nice learning\n",
+    "tool.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e55bfcc0-aef3-4538-9491-0c2b7a5cfe6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "\n",
+    "client = Client()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "739b5598-c8aa-4f6f-bdd4-634a8747a214",
+   "metadata": {},
+   "source": [
+    "<p>&#128070</p> Click the Dashboard link above. Or click the \"Search\" button in the dashboard.\n",
+    "\n",
+    "Let's test that the dashboard is working..\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a8d57c6-0ea8-4f59-bfb3-fa6e405da420",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.array\n",
+    "\n",
+    "dask.array.ones((1000, 4), chunks=(2, 1)).compute()  # should see activity in dashboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57eb5652-5d31-41b8-af1a-2c81a07af864",
+   "metadata": {},
+   "source": [
+    "Let's open a dataset. We specify `chunks` so that we create a dask arrays for the DataArrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db68e508-a095-4487-8cb2-8dbefb29708d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.tutorial.open_dataset(\"air_temperature\", chunks={\"time\": 100})\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbff39fd-60ed-43d0-8cee-339850ac3f2e",
+   "metadata": {},
+   "source": [
+    "## Simple example\n",
+    "\n",
+    "Here is an example"
    ]
   },
   {
@@ -76,6 +175,16 @@
     "result. This approach cannot work in all cases For such advanced use cases,\n",
     "`map_blocks` allows a `template` kwarg. See\n",
     "https://xarray.pydata.org/en/latest/dask.html#map-blocks for more details\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1353ece-153b-4bc6-a9e5-078ad003d9b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
    ]
   }
  ],

--- a/advanced/parallel-intro.md
+++ b/advanced/parallel-intro.md
@@ -1,0 +1,19 @@
+# Parallelizing custom functions
+
+Almost all of xarray’s built-in operations work on Dask arrays.
+
+Sometimes analysis calls for functions that aren't in xarray's API (e.g. scipy).
+There are three ways to apply these functions in parallel on each block of your
+xarray object:
+
+1. Extract Dask arrays from xarray objects ([.data](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.data.html)) and use Dask directly e.g.
+   ([apply_gufunc](https://docs.dask.org/en/latest/generated/dask.array.gufunc.apply_gufunc.html), [map_blocks](https://docs.dask.org/en/latest/generated/dask.array.map_blocks.html), [map_overlap](https://docs.dask.org/en/latest/generated/dask.array.map_overlap.html), [blockwise](https://docs.dask.org/en/latest/generated/dask.array.core.blockwise.html), [reduction](https://docs.dask.org/en/latest/generated/dask.array.reduction.html)). Then wrap the result as an Xarray object.
+
+2. Use [apply_ufunc](https://xarray.pydata.org/en/stable/generated/xarray.apply_ufunc.html) to apply functions that consume and return duck arrays. This automates extracting the data from Xarray objects, applying a function, and then converting the bare array result back to a Xarray object.
+
+3. Use [map_blocks](https://docs.xarray.dev/en/stable/generated/xarray.map_blocks.html), [Dataset.map_blocks](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.map_blocks.html) or [DataArray.map_blocks](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.map_blocks.html)
+   to apply functions that consume and return xarray objects.
+
+Which method you use ultimately depends on the type of input objects expected by
+the function you're wrapping, and the level of performance or convenience you
+desire.


### PR DESCRIPTION
Could use some input here.

1. I like the idea of having apply_ufunc and map_blocks as dropdowns. Optimistically, we'll have 4-5 notebooks here, and the material is advanced enough that it's nice to break it up.

2. But we need some high-level intro as shown in the screenshot. Right now it looks funny on its own in the left sidebar. We cannot make it a top-level heading with apply_ufunc and map_blocks as subheadings because then we'd lose the ability to do 1.

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/2448579/176078875-91daf2ed-3b63-4f9a-9fd8-e0e3686b9253.png">


Any ideas on how to resolve this? Alternatively maybe this type of intro should move to the narrative docs (docs.xarray.dev)