### PR TITLE
simplify dask notebook, enable binder dask-labextension dashboard

### DIFF
--- a/intermediate/xarray_and_dask.ipynb
+++ b/intermediate/xarray_and_dask.ipynb
@@ -1,7 +1,7 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "metadata": {},
    "source": [
     "<img src=\"http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png\" align=\"right\" width=\"30%\">\n",
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dask actually contructs a graph of the required computation. Here it's pretty simple: The full array is subdivided into 3 arrays. Dask will load each of these subarrays in a separate thread using the default [single-machine scheduling](https://docs.dask.org/en/stable/scheduling.html). You can look at dask 'task graphs' which represent the requested computation:"
+    "Dask actually constructs a graph of the required computation. Here it's pretty simple: The full array is subdivided into 3 arrays. Dask will load each of these subarrays in a separate thread using the default [single-machine scheduling](https://docs.dask.org/en/stable/scheduling.html). You can visualize dask 'task graphs' which represent the requested computation:"
    ]
   },
   {

--- a/intermediate/xarray_and_dask.ipynb
+++ b/intermediate/xarray_and_dask.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "<img src=\"http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png\" align=\"right\" width=\"30%\">\n",
     "\n",
-    "# Dask\n",
+    "# Parallel computing with Dask\n",
     "\n",
-    "This notebook demonstrates one of xarray's most powerful features: the ability\n",
+    "This notebook demonstrates one of Xarray's most powerful features: the ability\n",
     "to wrap [dask arrays](https://docs.dask.org/en/stable/array.html) and allow users to seamlessly execute analysis code in\n",
     "parallel.\n",
     "\n",
@@ -17,7 +17,21 @@
     "1. Xarray DataArrays and Datasets are \"dask collections\" i.e. you can execute\n",
     "   top-level dask functions such as `dask.visualize(xarray_object)`\n",
     "2. Learn that all xarray built-in operations can transparently use dask\n",
-    "\n"
+    "\n",
+    "\n",
+    "**Important:** *Using Dask does not always make your computations run faster!* Performance will depend on the computational infrastructure you're using (for example, how many CPU cores), how the data you're working with is structured and stored, and the algorithms and code you're running. Be sure to review the [Dask best-practices](https://docs.dask.org/en/stable/best-practices.html) if you're new to Dask!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='readwrite'></a>\n",
+    "\n",
+    "## Reading data\n",
+    "\n",
+    "The `chunks` argument to both `open_dataset` and `open_mfdataset` allow you to\n",
+    "read datasets as dask arrays. \n"
    ]
   },
   {
@@ -26,19 +40,120 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.tutorial.open_dataset(\n",
+    "    \"air_temperature\",\n",
+    "    chunks={  # this tells xarray to open the dataset as a dask array\n",
+    "        \"lat\": 25,\n",
+    "        \"lon\": 25,\n",
+    "        \"time\": -1,\n",
+    "    },\n",
+    ")\n",
+    "ds.air"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First lets set up a `LocalCluster` using [dask.distributed](https://distributed.dask.org/).\n",
+    "The representation (\"repr\" in Python parlance) for the `air` DataArray shows the very nice HTML dask array repr. You can access the underlying chunk sizes using `.chunks`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.air.chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Tip**: All variables in a `Dataset` need _not_ have the same chunk size along\n",
+    "common dimensions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='compute'></a>\n",
     "\n",
-    "You can use any kind of dask cluster. This step is completely independent of\n",
+    "## lazy computation \n",
+    "\n",
+    "Xarray seamlessly wraps dask so all computation is deferred until explicitly\n",
+    "requested."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean = ds.air.mean(\"time\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dask actually contructs a graph of the required computation. Here it's pretty simple: The full array is subdivided into 3 arrays. Dask will load each of these subarrays in a separate thread using the default [single-machine scheduling](https://docs.dask.org/en/stable/scheduling.html). You can look at dask 'task graphs' which represent the requested computation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean.data.visualize(optimize_graph=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting concrete values from dask arrays\n",
+    "\n",
+    "At some point, you will want to actually get concrete values (_usually_ a numpy array) from dask.\n",
+    "\n",
+    "There are two ways to compute values on dask arrays.\n",
+    "\n",
+    "1. `.compute()` returns an xarray object\n",
+    "2. `.load()` replaces the dask array in the xarray object with a numpy array.\n",
+    "   This is equivalent to `ds = ds.compute()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Distributed Clusters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As your data volumes grow and algorithms get more complex it can be hard to print out task graph representations and understand what Dask is doing behind the scenes. Luckily, you can use Dask's 'Distributed' scheduler to get very useful diagnotisic information.\n",
+    "\n",
+    "First let's set up a `LocalCluster` using [dask.distributed](https://distributed.dask.org/).\n",
+    "\n",
+    "You can use any kind of Dask cluster. This step is completely independent of\n",
     "xarray. While not strictly necessary, the dashboard provides a nice learning\n",
-    "tool.\n"
+    "tool."
    ]
   },
   {
@@ -49,7 +164,14 @@
    "source": [
     "from dask.distributed import Client\n",
     "\n",
-    "client = Client()\n",
+    "# This piece of code is just for a correct dashboard link mybinder.org or other JupyterHub demos\n",
+    "import dask\n",
+    "import os\n",
+    "\n",
+    "if os.environ.get('JUPYTERHUB_USER'):\n",
+    "    dask.config.set(**{\"distributed.dashboard.link\": \"/user/{JUPYTERHUB_USER}/proxy/{port}/status\"})\n",
+    "\n",
+    "client = Client(local_directory='/tmp')\n",
     "client"
    ]
   },
@@ -57,9 +179,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<p>&#128070</p> Click the Dashboard link above. Or click the \"Search\" button in the dashboard.\n",
+    "☝️ Click the Dashboard link above. \n",
     "\n",
-    "Let's test that the dashboard is working..\n"
+    "👈 Or click the \"Search\" 🔍 button in the [dask-labextension](https://github.com/dask/dask-labextension) dashboard.\n",
+    "\n",
+    "NOTE: if using the dask-labextension, you should disable the 'Simple' JupyterLab interface (`View -> Simple Interface`), so that you can drag and rearrange whichever dashboards you want. The `Workers` and `Task Stream` are good to make sure the dashboard is working!"
    ]
   },
   {
@@ -77,37 +201,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='readwrite'></a>\n",
-    "\n",
-    "## Reading data with Dask and Xarray\n",
-    "\n",
-    "The `chunks` argument to both `open_dataset` and `open_mfdataset` allow you to\n",
-    "read datasets as dask arrays. See\n",
-    "https://xarray.pydata.org/en/stable/dask.html#reading-and-writing-data for more\n",
-    "details\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.tutorial.open_dataset(\n",
-    "    \"air_temperature\",\n",
-    "    chunks={  # this tells xarray to open the dataset as a dask array\n",
-    "        \"lat\": 25,\n",
-    "        \"lon\": 25,\n",
-    "        \"time\": -1,\n",
-    "    },\n",
-    ")\n",
-    "ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Examining a DataArray with dask"
    ]
   },
@@ -115,69 +208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The repr for the `air` DataArray shows the very nice dask repr.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds.air"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Access the underlying chunk sizes using `.chunks`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds.air.chunks"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Tip**: All variables in a `Dataset` need _not_ have the same chunk size along\n",
-    "common dimensions.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='compute'></a>\n",
-    "\n",
-    "## Parallel/streaming/lazy computation using dask.array with Xarray\n",
-    "\n",
-    "Xarray seamlessly wraps dask so all computation is deferred until explicitly\n",
-    "requested\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mean = ds.air.mean(\"time\")  # no activity on dashboard\n",
-    "mean  # contains a dask array"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is true for all xarray operations including slicing\n"
+    "Let's go back to our xarray DataSet, in addition to computing the mean, other operations such as indexing will automatically use whichever Dask Cluster we are connected to!"
    ]
   },
   {
@@ -217,21 +248,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Getting concrete values from dask arrays\n",
-    "\n",
-    "At some point, you will want to actually get concrete values (_usually_ a numpy array) from dask.\n",
-    "\n",
-    "There are two ways to compute values on dask arrays.\n",
-    "\n",
-    "1. `.compute()` returns an xarray object\n",
-    "2. `.load()` replaces the dask array in the xarray object with a numpy array.\n",
-    "   This is equivalent to `ds = ds.compute()`\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -261,7 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But if we call `.load()`, `mean` will now contain a numpy array\n"
+    "But if we call `.load()`, `mean` will now contain a numpy array"
    ]
   },
   {
@@ -310,19 +326,7 @@
     "\n",
     "1. `.values` will always return a NumPy array. For dask-backed xarray objects,\n",
     "   this means that compute will always be called\n",
-    "2. `.data` will return a Dask array\n",
-    "\n",
-    "#### Exercise\n",
-    "\n",
-    "Try extracting a dask array from `ds.air`\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now extract a NumPy array from `ds.air`. Do you see compute activity on your\n",
-    "dashboard?\n"
+    "2. `.data` will return a Dask array"
    ]
   },
   {
@@ -337,21 +341,15 @@
     "\n",
     "### Exercise\n",
     "\n",
-    "Visualize the task graph for `mean`\n"
+    "Visualize the task graph for a few different computations on ds.air!"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visualize the task graph for `mean.data`. Is that the same as the above graph?\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Gracefully shutdown our client."
+    "\n",
+    "Gracefully shutdown our connection to the Dask cluster. This becomes more important when you are running on large HPC or Cloud servers rather than a laptop!"
    ]
   },
   {

--- a/intermediate/xarray_and_dask.ipynb
+++ b/intermediate/xarray_and_dask.ipynb
@@ -1,7 +1,7 @@
 {
  "cells": [
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<img src=\"http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png\" align=\"right\" width=\"30%\">\n",


### PR DESCRIPTION
Depending on interest I might go over this at scipy and show a larger demo with a gateway cluster on planetary computer

- reorganize to show chunking basics at top
- explain distributed and dashboard later down
- fix dashboard on mybinder.org
- links to more docs