### PR TITLE
Remove `continue-on-error` in QC workflow

### DIFF
--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -40,7 +40,6 @@ jobs:
             yaml.dump(data, f)
 
       - name: Check External Links
-        continue-on-error: true
         if: always()
         run: |
           jupyter-book build ./ --builder linkcheck


### PR DESCRIPTION
With #135, the link check now passes.