### PR TITLE
Align reduce callable with exercise description

### DIFF
--- a/intermediate/01-high-level-computation-patterns.ipynb
+++ b/intermediate/01-high-level-computation-patterns.ipynb
@@ -322,7 +322,7 @@
    "outputs": [],
    "source": [
     "# exactly equivalent to data.rolling(...).mean()\n",
-    "data.rolling(lat=5, lon=5, center=True).reduce(np.ptp).plot()"
+    "data.rolling(lat=5, lon=5, center=True).reduce(np.mean).plot()"
    ]
   },
   {
@@ -526,7 +526,7 @@
    },
    "outputs": [],
    "source": [
-    "(data.coarsen(lat=5, lon=5, boundary=\"trim\").reduce(np.ptp).plot())"
+    "(data.coarsen(lat=5, lon=5, boundary=\"trim\").reduce(np.mean).plot())"
    ]
   },
   {

--- a/overview/get-started.md
+++ b/overview/get-started.md
@@ -15,7 +15,7 @@ Be patient, it can take a few minutes for a server to become available on the Cl
 
 **1. On your computer:** Running tutorials on your computer requires some setup:
 
-We recommend using [`conda-lock`](https://conda-incubator.github.io/conda-lock/) to ensure a fully reproducible Python environment
+We recommend using [`conda-lock`](https://conda.github.io/conda-lock/) to ensure a fully reproducible Python environment
 
 ```
 git clone https://github.com/xarray-contrib/xarray-tutorial.git


### PR DESCRIPTION
Small fix updating the code (using np.ptp) with the exercise description (using np.mean).

Also fixes a broken link