### PR TITLE
Minor Update 01.1_io.ipynb

### DIFF
--- a/fundamentals/01.1_io.ipynb
+++ b/fundamentals/01.1_io.ipynb
@@ -61,7 +61,7 @@
     "  [coordinates](#coordinates) except we need to use either `DataArray` objects\n",
     "  or the tuple syntax since we have to provide dimensions\n",
     "- `coords`: same as for `DataArray`\n",
-    "- `attrs`: same as for `Dataset`"
+    "- `attrs`: same as for `DataArray`"
    ]
   },
   {
@@ -191,7 +191,7 @@
    "id": "6cbebf89-7a64-4af6-af7f-04c906bfbeac",
    "metadata": {},
    "source": [
-    "**tip:** You can write to any diictionary-like (`MutableMapping`) interface:"
+    "**tip:** You can write to any dictionary-like (`MutableMapping`) interface:"
    ]
   },
   {


### PR DESCRIPTION
Change 1: 
Changed description of the attrs parameter for Dataset from "same as for Dataset" to "same as for DataArray".  This may be an oversight carried forward from 01.1 where the same description is given.

Change 2:
Minor typographical error corrected (diictionary -> dictionary)