### PR TITLE
contents write permissions for github token

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
Publishing via CI is currently failing (https://github.com/xarray-contrib/xarray-tutorial/actions/runs/5160901491)

`Action failed with "The process '/usr/bin/git' failed with exit code 128"`

According to these docs, contents: write permission should fix it
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token