### PR TITLE
Change concurrency group

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: 'pages'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write # allow surge-preview to create/update PR comments
 
 concurrency:
-  group: 'preview'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/qaqc.yaml
+++ b/.github/workflows/qaqc.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: 'qaqc'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
using a static name was causing PRs and main branch merges to cancel each other, might be better to simply have separate 'test' and 'deploy' workflows

https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow