### PR TITLE
use `simplecache` instead of `filecache`

### DIFF
--- a/intermediate/remote_data/remote-data.ipynb
+++ b/intermediate/remote_data/remote-data.ipynb
@@ -250,7 +250,7 @@
     "\n",
     "uri = \"https://its-live-data.s3-us-west-2.amazonaws.com/test-space/sample-data/sst.mnmean.nc\"\n",
     "# we prepend the cache type to the URI, this is called protocol chaining in fsspec-speak\n",
-    "file = fsspec.open_local(f\"simplecache::{uri}\", filecache={'cache_storage': '/tmp/fsspec_cache'})\n",
+    "file = fsspec.open_local(f\"simplecache::{uri}\", simplecache={'cache_storage': '/tmp/fsspec_cache'})\n",
     "\n",
     "ds = xr.open_dataset(file, engine=\"netcdf4\")\n",
     "ds"


### PR DESCRIPTION
Options for different protocol layers are passed by the name of the protocol, so it should be `simplecache` instead of `filecache`.