### PR TITLE
Fix typo in xarray-in-45-min.ipynb

### DIFF
--- a/overview/xarray-in-45-min.ipynb
+++ b/overview/xarray-in-45-min.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "`.dims` correspond to the axes of your data. \n",
     "\n",
-    "In this case we have 2 spatial dimensions (`latitude` and `longitude` are store with shorthand names `lat` and `lon`) and one temporal dimension (`time`)."
+    "In this case we have 2 spatial dimensions (`latitude` and `longitude` are stored with shorthand names `lat` and `lon`) and one temporal dimension (`time`)."
    ]
   },
   {


### PR DESCRIPTION
This PR changes the word "store" to "stored" in the following sentence:

```
`latitude` and `longitude` are store with shorthand names `lat` and `lon`
```