### PR TITLE
Fix _FillValue note

### DIFF
--- a/overview/xarray-in-45-min.ipynb
+++ b/overview/xarray-in-45-min.ipynb
@@ -922,7 +922,7 @@
    "metadata": {},
    "source": [
     "```{note}\n",
-    "To avoid the `SerializationWarning` you can assign a _FillValue for any NaNs in 'air' array by adding the keyword argument encoding=dict(air={_FillValue=-9999})\n",
+    "To avoid the `SerializationWarning` you can assign a _FillValue for any NaNs in 'air' array by adding the keyword argument `encoding=dict(air=dict(_FillValue=-9999))`\n",
     "```"
    ]
   },


### PR DESCRIPTION
This PR fixes a syntax error in the `encoding` argument in the note explaining how to avoid a `SerializationWarning` in the "Xarray in 45 minutes" tutorial.