### PR TITLE
Minor correction in advanced-indexing.ipynb

### DIFF
--- a/intermediate/indexing/advanced-indexing.ipynb
+++ b/intermediate/indexing/advanced-indexing.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "**Pointwise** or **Vectorized indexing**, shown on the left, selects specific elements at given coordinates, resulting in an array of those individual elements. In the example shown, the indices `[0, 2, 4]`, `[0, 2, 4]` select the elements at positions `(0, 0)`, `(2, 2)`, and `(4, 4)`, resulting in the values `[1, 13, 25]`. This is the default behavior of NumPy arrays.\n",
     "  \n",
-    "In contrast, **orthogonal indexing** uses the same indices to select entire rows and columns, forming a cross-product of the specified indices. This method results in sub-arrays that include all combinations of the selected rows and columns. The example demonstrates this by selecting rows 0, 2, and 4 and columns 0, 2, and 4, resulting in a subarray containing `[[1, 3, 5], [11, 13, 15], [21, 23, 25]]`. This is Xarray DataArray's default behavior.\n",
+    "In contrast, **orthogonal indexing** uses the same indices to select entire rows and columns, forming the Cartesian product of the specified indices. This method results in sub-arrays that include all combinations of the selected rows and columns. The example demonstrates this by selecting rows 0, 2, and 4 and columns 0, 2, and 4, resulting in a subarray containing `[[1, 3, 5], [11, 13, 15], [21, 23, 25]]`. This is Xarray DataArray's default behavior.\n",
     " \n",
     "The output of vectorized indexing is a `1D array`,  while the output of orthogonal indexing is a `3x3` array.   \n",
     "\n",


### PR DESCRIPTION
The product described here is the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product), not a [cross product](https://en.wikipedia.org/wiki/Cross_product). xarray does also implement the [cross product](https://docs.xarray.dev/en/stable/generated/xarray.cross.html), which is another reason to avoid confusion here.