### PR TITLE
Fixed typo and increase clarity on non-dimension coordinate variable vs name

### DIFF
--- a/fundamentals/01.1_creating_data_structures.ipynb
+++ b/fundamentals/01.1_creating_data_structures.ipynb
@@ -241,7 +241,7 @@
     "\n",
     "Sometimes we want to attach coordinate variables along an existing dimension. Notice that \n",
     "1. `itime` is not bolded and \n",
-    "2. has a name \"time\" that is different from the dimension name \"time\"\n",
+    "2. has a variable name \"itime\" that is different from the dimension name \"time\"\n",
     "\n",
     "`itime` is an example of a non-dimension coordinate variable i.e. it is a coordinate variable that does not match a dimension name. Here we demonstrate the \"tuple\" form of assigninment:  `(dims, data, attrs)`"
    ]

--- a/fundamentals/01.1_creating_data_structures.ipynb
+++ b/fundamentals/01.1_creating_data_structures.ipynb
@@ -241,7 +241,7 @@
     "\n",
     "Sometimes we want to attach coordinate variables along an existing dimension. Notice that \n",
     "1. `itime` is not bolded and \n",
-    "2. has a variable name \"itime\" that is different from the dimension name \"time\"\n",
+    "2. has a coordinate variable \"itime\" that is different from the dimension name \"time\"\n",
     "\n",
     "`itime` is an example of a non-dimension coordinate variable i.e. it is a coordinate variable that does not match a dimension name. Here we demonstrate the \"tuple\" form of assigninment:  `(dims, data, attrs)`"
    ]


### PR DESCRIPTION
- Typo: an "i" was missing in the quoted name.
- It was unclear which is the variable name and which is the dimension name, thus I made editorial changes to improve clarity.