### PR TITLE
Fixed typo in rolling or moving window section

### DIFF
--- a/fundamentals/03.3_windowed.ipynb
+++ b/fundamentals/03.3_windowed.ipynb
@@ -62,7 +62,7 @@
     "Rolling window operations \n",
     "1. can be applied along any dimension, or along multiple dimensions.\n",
     "2. returns object of same shape as input\n",
-    "3. pads with NaNs to make (3) possible\n",
+    "3. pads with NaNs to make (2) possible\n",
     "\n",
     "Again, all common reduction operations are [available](https://docs.xarray.dev/en/stable/api.html#rolling-objects)"
    ]


### PR DESCRIPTION
The `NaN` padding makes it possible to return an output with the same shape as the input.